### PR TITLE
Fix typo in warning message about the non-supported OS X version

### DIFF
--- a/knockknock.py
+++ b/knockknock.py
@@ -262,7 +262,7 @@ def initKK():
 	if not utils.isSupportedOS():
 
 		#dbg msg
-		utils.logMessage(utils.MODE_WARN, '%s is not an officially supported OS X version (you milage may vary)' % ('.'.join(utils.getOSVersion())))
+		utils.logMessage(utils.MODE_WARN, '%s is not an officially supported OS X version (your mileage may vary)' % ('.'.join(utils.getOSVersion())))
 
 	#dbg msg
 	else:


### PR DESCRIPTION
Hi,
If 'you milage' is intentional, please feel free to reject. Won't be offended. But I've found it quite annoying, and changed it in my local copy, so thought could be nice to share.
Regards!
J.