### PR TITLE
Whitelisting Safari Adblocker

### DIFF
--- a/extension.py
+++ b/extension.py
@@ -50,7 +50,8 @@ class Extension():
 			self.description = extensionInfo['description']
 
 		#init whitelist flag
-		self.isWhitelisted = (self.extensionID in whitelist.whitelistedExtensions)
++               whitelistedSearch = self.extensionID if self.extensionID != None else self.path
++               self.isWhitelisted = (whitelistedSearch in whitelist.whitelistedExtensions)
 
 		return
 

--- a/extension.py
+++ b/extension.py
@@ -50,8 +50,8 @@ class Extension():
 			self.description = extensionInfo['description']
 
 		#init whitelist flag
-+               whitelistedSearch = self.extensionID if self.extensionID != None else self.path
-+               self.isWhitelisted = (whitelistedSearch in whitelist.whitelistedExtensions)
+                whitelistedSearch = self.extensionID if self.extensionID != None else self.path
+                self.isWhitelisted = (whitelistedSearch in whitelist.whitelistedExtensions)
 
 		return
 


### PR DESCRIPTION
Change allows to whitelist browser extensions by path, useful if there is no id available.