### PR TITLE
Fix KnockKnock detection bypass

### DIFF
--- a/knockknock.py
+++ b/knockknock.py
@@ -89,11 +89,17 @@ def knocknock():
 					# ->depending on args, singed by apple, whitelisted, etc
 					if isinstance(startupObj, file.File):
 
-						#by default, ignore signed by Apple in /System (protected by SIP)
-						if not args.apple and startupObj.signedByApple and startupObj.plist.startswith('/System'):
+						#by default, ignore signed by Apple
+						if not args.apple and startupObj.signedByApple:
 
-							#add to list
-							ignoredItems.append(startupObj)
+							if startupObj.plist == None:
+								#add to list
+								ignoredItems.append(startupObj)
+							else:
+								# ignore signed by Apple in /System (protected by SIP) for LaunchAgents/LaunchDaemons
+								if startupObj.plist.startswith('/System'):
+									#add to list
+									ignoredItems.append(startupObj)
 
 					#ignore white listed items
 					if not args.whitelist and startupObj.isWhitelisted:

--- a/knockknock.py
+++ b/knockknock.py
@@ -89,8 +89,8 @@ def knocknock():
 					# ->depending on args, singed by apple, whitelisted, etc
 					if isinstance(startupObj, file.File):
 
-						#by default, ignore signed by Apple
-						if not args.apple and startupObj.signedByApple:
+						#by default, ignore signed by Apple in /System (protected by SIP)
+						if not args.apple and startupObj.signedByApple and startupObj.plist.startswith('/System'):
 
 							#add to list
 							ignoredItems.append(startupObj)


### PR DESCRIPTION
This fixes #30

- Files that are signed by Apple are ignored by default only in /System for LaunchDaemons-LaunchAgents
- When a file does not exist, instead of being directly ignored, path is fixed if it's an alias otherwise it's ignored